### PR TITLE
load up a local emacs conf files if it exists in ~/.emacs.d.local

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -7,6 +7,10 @@
 ;; use spaces for tabs
 (setq-default indent-tabs-mode nil)
 
+;; load up local conf if it exists
+(if (file-exists-p (expand-file-name "~/.emacs.d.local"))
+    (load-file (expand-file-name "~/.emacs.d.local")))
+
 ;; set default font size based on operating system
 ;; height is in 1/10 pt
 (cond


### PR DESCRIPTION
- created so can add erlang mode regardless of where or what operating
  system or what version installed it.