### PR TITLE
Fix broken logic for alchemist requiring emacs 24.4 or later.

### DIFF
--- a/.emacs.d/config.org
+++ b/.emacs.d/config.org
@@ -340,8 +340,9 @@ Alchemist is only supported on emacs 24.4 and later
 
 #+begin_src emacs-lisp
 (use-package alchemist
-  :if (and (>= emacs-major-version 24)
-           (>= emacs-minor-version 4))
+  :if (or (and (= emacs-major-version 24)
+               (>= emacs-minor-version 4))
+          (>= emacs-major-version 25))
   :init
   (use-package elixir-mode))
 #+end_src

--- a/.emacs.d/custom.el
+++ b/.emacs.d/custom.el
@@ -10,7 +10,7 @@
  '(org-hide-emphasis-markers t)
  '(package-selected-packages
    (quote
-    (feature-mode geiser flycheck yasnippet yaml-mode use-package markdown-mode magit helm exec-path-from-shell evil ess emmet-mode)))
+    (alchemist feature-mode geiser flycheck yasnippet yaml-mode use-package markdown-mode magit helm exec-path-from-shell evil ess emmet-mode)))
  '(tramp-default-method "ssh"))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.


### PR DESCRIPTION
- Minor version requirement only needed on version 24.